### PR TITLE
fix $access_token->session_freeze; typo on line 156 in AccessToken.pm

### DIFF
--- a/lib/Net/OAuth2/AccessToken.pm
+++ b/lib/Net/OAuth2/AccessToken.pm
@@ -153,7 +153,7 @@ the values inside the $session.
 =example
   my $auth    = Net::OAuth2::Profile::WebServer->new(...);
   my $token   = $auth->get_access_token(...);
-  my $session = $token->freeze_session;
+  my $session = $token->session_freeze;
   # now save $session in database or file
   ...
   # restore session


### PR DESCRIPTION
hey Mark, found a small typo in the example from Net::OAuth2::AccessToken.

thanks for making this module!