### PR TITLE
Replace JSON with JSON::MaybeXS

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -8,7 +8,7 @@ WriteMakefile
      { Test::More => 0
      , YAML => 0
      , URI  => '0'
-     , JSON => '0'
+     , JSON::MaybeXS  => '0'
      , LWP::UserAgent => '0'
      , Scalar::Util   => 0
      , HTTP::Request  => 0

--- a/lib/Net/OAuth2/AccessToken.pm
+++ b/lib/Net/OAuth2/AccessToken.pm
@@ -8,9 +8,9 @@ use strict;
 
 our $VERSION;  # to be able to test in devel environment
 
-use JSON        qw/encode_json/;
-use URI::Escape qw/uri_escape/;
-use Encode      qw/find_encoding/;
+use JSON::MaybeXS qw/encode_json/;
+use URI::Escape   qw/uri_escape/;
+use Encode        qw/find_encoding/;
 
 # Attributes to be saved to preserve the session.
 my @session = qw/access_token token_type refresh_token expires_at

--- a/lib/Net/OAuth2/Profile.pm
+++ b/lib/Net/OAuth2/Profile.pm
@@ -9,7 +9,7 @@ use strict;
 
 use LWP::UserAgent ();
 use URI            ();
-use JSON           qw/decode_json/;
+use JSON::MaybeXS  qw/decode_json/;
 use Carp           qw/confess carp/;
 use Scalar::Util   qw/blessed/;
 use Encode         qw/encode/;

--- a/t/30refresh.t
+++ b/t/30refresh.t
@@ -4,13 +4,13 @@ use warnings FATAL => "all";
 
 use Test::More;
 use HTTP::Response;
-use JSON;
+use JSON::MaybeXS;
 
 use Net::OAuth2;
 use Net::OAuth2::AccessToken;
 use Net::OAuth2::Profile::WebServer;
 
-my $json = JSON->new;
+my $json = JSON::MaybeXS->new;
 
 BEGIN {
    eval "require Test::Mock::LWP::Dispatch";


### PR DESCRIPTION
JSON::MaybeXS is the current favoured compatibility layer above
the various JSON backends. It used to be JSON, then JSON::Any,
now this. It is used by a few hundred modules on CPAN.